### PR TITLE
Avoid sns errors;Replace deprecated method;Remember previously added …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
       <version>4.10</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.onehippo.cms7</groupId>
+      <artifactId>hippo-repository-connector</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
…members

Main changes I propose are:
Avoid writing deltas by removing the nodes everytime the auth document gets published.
Since I remove the nodes, I added code to remember the previously added members
use importEnhancedSystemViewXML instead of importDereferencedXML
acquire session everytime and release it.